### PR TITLE
chore(release): Adopt parent img from quay to avoid pull rate limit errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 as build-deps
+FROM quay.io/cdis/golang:1.14 as build-deps
 
 RUN mkdir -p /go/src/github.com/uc-cdis/indexs3client
 WORKDIR /go/src/github.com/uc-cdis/indexs3client


### PR DESCRIPTION
Small fix to unblock the `integration202101` release testing.