### PR TITLE
Revert "Ramu testindexs3client (#31)".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # indexs3client
 S3 index client service
+
+This container runs inside the ephemeral `indexing` pod, which is triggered by the `ssjdispatcher` pod based on data upload messages that sit on an AWS SQS queue.

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -79,21 +78,13 @@ func IndexS3Object(s3objectURL string) {
 	//     <dataguid>/<uuid>/<filename>
 	//
 	// we want to keep the `<dataguid>/<uuid>` part
-	if len(key) > 0 && strings.HasPrefix(key, "/") {
-		key = strings.TrimPrefix(key, "/")
-	}
-
 	split_key := strings.Split(key, "/")
 	var uuid string
-	found, err := regexp.MatchString("[a-z]{2}\\.[a-fA-F0-9]+", split_key[0])
-	if err == nil && !found {
+	if len(split_key) == 2 {
 		uuid = split_key[0]
-	} else if err == nil && found {
-		uuid = strings.Join(split_key[:2], "/")
 	} else {
-		log.Printf("cannot process the UUID")
+		uuid = strings.Join(split_key[:len(split_key)-1], "/")
 	}
-
 	filename := split_key[len(split_key)-1]
 	fileExtension := filepath.Ext(filename)
 	if len(fileExtension) > 0 {


### PR DESCRIPTION
This reverts commit c923aff416e74023dba6bbe34c46a3cc6a5ce721.

This PR https://github.com/uc-cdis/indexs3client/pull/31 introduces a bug; indexs3client tries to get the indexd record using the GUID’s prefix only, instead of the whole GUID

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

