### PR TITLE
PXP-7648 - updated parsing logic for guid

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -81,23 +81,11 @@ func IndexS3Object(s3objectURL string) {
 	//
 	// we want to keep the `<dataguid>/<uuid>` part
 	key = strings.Trim(key, "/")
-	split_key := strings.Split(key, "/")
-	var uuid string
-	var filename string
-	// here uuid can be dg.XXXX/<uuid> or
-	// just <uuid> to distinguish between
-	// them and to keep the filename consistent
-	foundGUID, errGUID := id.Parse(split_key[0])
-	foundPrefix, errPrefix := id.Parse(split_key[1])
-	if errGUID == nil && len(foundGUID) > 0 {
-		uuid = split_key[0]
-		filename = split_key[len(split_key)-1]
-	} else if errPrefix == nil && len(foundPrefix) > 0 {
-		uuid = strings.Join(split_key[:2], "/")
-		filename = strings.Join(split_key[2:], "/")
-	} else {
-		fmt.Println("cannot process the UUID")
+	var uuid, filename, errUUID = CreateUUID(key)
+	if errUUID != nil {
+		log.Panicf(errUUID.Error())
 	}
+
 	fileExtension := filepath.Ext(filename)
 	if len(fileExtension) > 0 {
 		fileExtension = fileExtension[1:]
@@ -146,4 +134,25 @@ func IndexS3Object(s3objectURL string) {
 	log.Printf("Updated Indexd record %s with hash info. Response Status Code: %d", uuid, resp.StatusCode)
 
 	updateMetadataObjectWrapper(uuid, configInfo, mdsUploadedBody)
+}
+
+func CreateUUID(key string) (string, string, error) {
+	split_key := strings.Split(key, "/")
+	var uuid string
+	var filename string
+	// here uuid can be dg.XXXX/<uuid> or
+	// just <uuid> to distinguish between
+	// them and to keep the filename consistent
+	foundGUID, errGUID := id.Parse(split_key[0])
+	foundPrefix, errPrefix := id.Parse(split_key[1])
+	if errGUID == nil && len(foundGUID) > 0 {
+		uuid = split_key[0]
+		filename = split_key[len(split_key)-1]
+	} else if errPrefix == nil && len(foundPrefix) > 0 {
+		uuid = strings.Join(split_key[:2], "/")
+		filename = strings.Join(split_key[2:], "/")
+	} else {
+		return "", "", fmt.Errorf("Cannot process the UUID")
+	}
+	return uuid, filename, nil
 }

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -84,12 +84,15 @@ func IndexS3Object(s3objectURL string) {
 	split_key := strings.Split(key, "/")
 	var uuid string
 	var filename string
+	// here uuid can be dg.XXXX/<uuid> or
+	// just <uuid> to distinguish between
+	// them and to keep the filename consistent
 	foundGUID, errGUID := id.Parse(split_key[0])
-	foundDG, errDG := id.Parse(split_key[1])
+	foundPrefix, errPrefix := id.Parse(split_key[1])
 	if errGUID == nil && len(foundGUID) > 0 {
 		uuid = split_key[0]
 		filename = split_key[len(split_key)-1]
-	} else if errDG == nil && len(foundDG) > 0 {
+	} else if errPrefix == nil && len(foundPrefix) > 0 {
 		uuid = strings.Join(split_key[:2], "/")
 		filename = strings.Join(split_key[2:], "/")
 	} else {

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	id "github.com/google/uuid"
 )
 
 // MaxRetries maximum number of retries
@@ -78,12 +80,17 @@ func IndexS3Object(s3objectURL string) {
 	//     <dataguid>/<uuid>/<filename>
 	//
 	// we want to keep the `<dataguid>/<uuid>` part
+	key = strings.Trim(key, "/")
 	split_key := strings.Split(key, "/")
 	var uuid string
-	if len(split_key) == 2 {
+	foundGUID, errGUID := id.Parse(split_key[0])
+	foundDG, errDG := id.Parse(split_key[1])
+	if errGUID == nil && len(foundGUID) > 0 {
 		uuid = split_key[0]
+	} else if errDG == nil && len(foundDG) > 0 {
+		uuid = strings.Join(split_key[:2], "/")
 	} else {
-		uuid = strings.Join(split_key[:len(split_key)-1], "/")
+		fmt.Println("cannot process the UUID")
 	}
 	filename := split_key[len(split_key)-1]
 	fileExtension := filepath.Ext(filename)

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -81,7 +81,7 @@ func IndexS3Object(s3objectURL string) {
 	//
 	// we want to keep the `<dataguid>/<uuid>` part
 	key = strings.Trim(key, "/")
-	var uuid, filename, errUUID = CreateUUID(key)
+	var uuid, filename, errUUID = resolveUUID(key)
 	if errUUID != nil {
 		log.Panicf(errUUID.Error())
 	}
@@ -136,28 +136,23 @@ func IndexS3Object(s3objectURL string) {
 	updateMetadataObjectWrapper(uuid, configInfo, mdsUploadedBody)
 }
 
-func CreateUUID(key string) (string, string, error) {
-	split_key := strings.Split(key, "/")
-	var uuid string
+func resolveUUID(key string) (string, string, error) {
+	keyParts := strings.Split(key, "/")
+	uuidIndex := -1
+	var foundUUID id.UUID
+	var fullUUID string
 	var filename string
-	// here uuid can be dg.XXXX/<uuid> or
-	// just <uuid> to distinguish between
-	// them and to keep the filename consistent
-	foundGUID, errGUID := id.Parse(split_key[0])
-	var foundPrefix id.UUID
-	var errPrefix error
-	if len(split_key) > 1 {
-		foundPrefix, errPrefix = id.Parse(split_key[1])
+	for i, part := range keyParts {
+		foundUUID = id.Parse(part)
+		if foundUUID != id.Nil {
+			uuidIndex = i
+			break
+		}
 	}
-
-	if errGUID == nil && foundGUID != id.Nil {
-		uuid = split_key[0]
-		filename = split_key[len(split_key)-1]
-	} else if errPrefix == nil && foundPrefix != id.Nil {
-		uuid = strings.Join(split_key[:2], "/")
-		filename = strings.Join(split_key[2:], "/")
-	} else {
+	if uuidIndex == -1 {
 		return "", "", fmt.Errorf("Cannot process the UUID")
 	}
-	return uuid, filename, nil
+	fullUUID = strings.Join(keyParts[:uuidIndex+1], "/")
+	filename = strings.Join(keyParts[uuidIndex+1:], "/")
+	return fullUUID, filename, nil
 }

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -83,16 +83,18 @@ func IndexS3Object(s3objectURL string) {
 	key = strings.Trim(key, "/")
 	split_key := strings.Split(key, "/")
 	var uuid string
+	var filename string
 	foundGUID, errGUID := id.Parse(split_key[0])
 	foundDG, errDG := id.Parse(split_key[1])
 	if errGUID == nil && len(foundGUID) > 0 {
 		uuid = split_key[0]
+		filename = split_key[len(split_key)-1]
 	} else if errDG == nil && len(foundDG) > 0 {
 		uuid = strings.Join(split_key[:2], "/")
+		filename = strings.Join(split_key[2:], "/")
 	} else {
 		fmt.Println("cannot process the UUID")
 	}
-	filename := split_key[len(split_key)-1]
 	fileExtension := filepath.Ext(filename)
 	if len(fileExtension) > 0 {
 		fileExtension = fileExtension[1:]

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -144,11 +144,16 @@ func CreateUUID(key string) (string, string, error) {
 	// just <uuid> to distinguish between
 	// them and to keep the filename consistent
 	foundGUID, errGUID := id.Parse(split_key[0])
-	foundPrefix, errPrefix := id.Parse(split_key[1])
-	if errGUID == nil && len(foundGUID) > 0 {
+	var foundPrefix id.UUID
+	var errPrefix error
+	if len(split_key) > 1 {
+		foundPrefix, errPrefix = id.Parse(split_key[1])
+	}
+
+	if errGUID == nil && foundGUID != id.Nil {
 		uuid = split_key[0]
 		filename = split_key[len(split_key)-1]
-	} else if errPrefix == nil && len(foundPrefix) > 0 {
+	} else if errPrefix == nil && foundPrefix != id.Nil {
 		uuid = strings.Join(split_key[:2], "/")
 		filename = strings.Join(split_key[2:], "/")
 	} else {

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -140,11 +140,12 @@ func resolveUUID(key string) (string, string, error) {
 	keyParts := strings.Split(key, "/")
 	uuidIndex := -1
 	var foundUUID id.UUID
+	var err error
 	var fullUUID string
 	var filename string
 	for i, part := range keyParts {
-		foundUUID = id.Parse(part)
-		if foundUUID != id.Nil {
+		foundUUID, err = id.Parse(part)
+		if err == nil && foundUUID != id.Nil {
 			uuidIndex = i
 			break
 		}

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -163,3 +163,46 @@ func TestGetConfigInfoUsingExtraServiceInfo(t *testing.T) {
 	assert.Equal(t, configInfo.MetadataService.Username, "mr friendly cat")
 	assert.Equal(t, configInfo.MetadataService.Password, "paws")
 }
+
+func TestCreateUUID(t *testing.T) {
+	keys := []struct {
+		key      string
+		uuid     string
+		filename string
+	}{
+		{"dg.MD1R/00004ead-7ae8-48d9-9d87-c1e0eabbf651/TEST-12-AR/TEST-12-AR-16434369/01-05-2012-CT TEST TESTTEST TEST W-12234/4.1111111-ARTEST 1MM-758254/8-7654.dcm", "dg.MD1R/00004ead-7ae8-48d9-9d87-c1e0eabbf651", "TEST-12-AR/TEST-12-AR-16434369/01-05-2012-CT TEST TESTTEST TEST W-12234/4.1111111-ARTEST 1MM-758254/8-7654.dcm"},
+		{"dg.NACD/da85ab42-53a0-4698-9b38-7ad59b770b47/flies/moth.txt", "dg.NACD/da85ab42-53a0-4698-9b38-7ad59b770b47", "flies/moth.txt"},
+		{"dg.4825/da85ab42-53a0-4698-9b38-7ad59b770b47/flies/moth.txt", "dg.4825/da85ab42-53a0-4698-9b38-7ad59b770b47", "flies/moth.txt"},
+		{"dg.F738/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test1.txt", "dg.F738/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test1.txt"},
+		{"dg.80B6/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test2.txt", "dg.80B6/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test2.txt"},
+		{"dg.EA80/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test3.txt", "dg.EA80/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test3.txt"},
+		{"dg.5B0D/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test4.txt", "dg.5B0D/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test4.txt"},
+		{"dg.4503/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test5.txt", "dg.4503/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test5.txt"},
+		{"dg.373F/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test6.txt", "dg.373F/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test6.txt"},
+		{"dg.7519/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test7.txt", "dg.7519/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test7.txt"},
+		{"dg.7C5B/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test8.txt", "dg.7C5B/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test8.txt"},
+		{"dg.0896/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test9.txt", "dg.0896/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test9.txt"},
+		{"dg.F82A1A/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test10.txt", "dg.F82A1A/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test10.txt"},
+		{"dg.4DFC/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test11.txt", "dg.4DFC/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test11.txt"},
+		{"dg.712C/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test12.txt", "dg.712C/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test12.txt"},
+		{"dg.6VTS/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test13.txt", "dg.6VTS/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test13.txt"},
+		{"dg.63D5/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test14.txt", "dg.63D5/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test14.txt"},
+		{"dg.414F/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test15.txt", "dg.414F/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test15.txt"},
+		{"dg.6539/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test16.txt", "dg.6539/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test16.txt"},
+		{"dg.ANV0/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test17.txt", "dg.ANV0/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test17.txt"},
+		{"dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test18.txt", "dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test18.txt"},
+	}
+
+	for _, key := range keys {
+		uuid, filename, err := CreateUUID(key.key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if uuid != key.uuid {
+			t.Errorf("The UUID is invalid")
+		}
+		if filename != key.filename {
+			t.Errorf("The filename is invalid")
+		}
+	}
+}

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -191,6 +191,8 @@ func TestCreateUUID(t *testing.T) {
 		{"dg.6539/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test16.txt", "dg.6539/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test16.txt"},
 		{"dg.ANV0/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test17.txt", "dg.ANV0/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test17.txt"},
 		{"dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test18.txt", "dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test18.txt"},
+		{"da85ab42-53a0-4698-9b38-7ad59b770b47/test19.txt", "da85ab42-53a0-4698-9b38-7ad59b770b47", "test19.txt"},
+		{"dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47/test20.txt", "dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47", "test20.txt"},
 	}
 
 	for _, key := range keys {

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -193,10 +193,11 @@ func TestCreateUUID(t *testing.T) {
 		{"dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test18.txt", "dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test18.txt"},
 		{"da85ab42-53a0-4698-9b38-7ad59b770b47/test19.txt", "da85ab42-53a0-4698-9b38-7ad59b770b47", "test19.txt"},
 		{"dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47/test20.txt", "dg.MD1R/da85ab42-53a0-4698-9b38-7ad59b770b47", "test20.txt"},
+		{"da85ab42-53a0-4698-9b38-7ad59b770b47/files/prefixtest/test21.txt", "da85ab42-53a0-4698-9b38-7ad59b770b47", "files/prefixtest/test21.txt"},
 	}
 
 	for _, key := range keys {
-		uuid, filename, err := CreateUUID(key.key)
+		uuid, filename, err := resolveUUID(key.key)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
When a user uploads files using gen3-client  with  "--include-subdirname" option, in the indexed record for filename the dots (“.”) are replaced with slashes (“/”).

### New Features


### Breaking Changes


### Bug Fixes
This change will include parsing logic of uuid.

### Improvements


### Dependency updates


### Deployment changes

