### PR TITLE
PPS-2067 add log message for error from update

### DIFF
--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -121,6 +121,9 @@ func IndexS3Object(s3objectURL string) {
 		updateMetadataObjectWrapper(uuid, configInfo, mdsErrorBody)
 		log.Panicf("Could not update Indexd record %s. Error: %s", uuid, err)
 	} else if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == 403 {
+			log.Printf("Possible auth issue for Indexd user %s", configInfo.Indexd.Username)
+		}
 		updateMetadataObjectWrapper(uuid, configInfo, mdsErrorBody)
 		log.Panicf("Could not update Indexd record %s. Response Status Code: %d", uuid, resp.StatusCode)
 	}

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -121,9 +121,6 @@ func IndexS3Object(s3objectURL string) {
 		updateMetadataObjectWrapper(uuid, configInfo, mdsErrorBody)
 		log.Panicf("Could not update Indexd record %s. Error: %s", uuid, err)
 	} else if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == 403 {
-			log.Printf("Possible auth issue for Indexd user %s", configInfo.Indexd.Username)
-		}
 		updateMetadataObjectWrapper(uuid, configInfo, mdsErrorBody)
 		log.Panicf("Could not update Indexd record %s. Response Status Code: %d", uuid, resp.StatusCode)
 	}

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -81,7 +81,7 @@ func IndexS3Object(s3objectURL string) {
 	key = strings.Trim(key, "/")
 	var uuid, errUUID = resolveUUID(key)
 	if errUUID != nil {
-		log.Panicf(errUUID.Error())
+		log.Panicf("UUID error %s", errUUID.Error())
 	}
 
 	log.Printf("Attempting to get rev for record %s in Indexd", uuid)

--- a/handlers/indexs3object.go
+++ b/handlers/indexs3object.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -29,7 +29,7 @@ func GetIndexdRecordRev(uuid, indexURL string) (string, error) {
 		return "", fmt.Errorf("Can not get rev of the record %s. IndexURL %s. Status code: %d", uuid, indexURL, resp.StatusCode)
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	var data interface{}
 
@@ -60,6 +60,9 @@ func UpdateIndexdRecord(uuid, rev string, indexdInfo *IndexdInfo, body []byte) (
 	client := retryablehttp.NewClient()
 	client.RetryMax = MaxRetries
 	resp, err := client.Do(req)
+	if resp.StatusCode == 403 {
+		log.Printf("Possible auth issue for Indexd user %s", indexdInfo.Username)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/handlers/indexs3object.go
+++ b/handlers/indexs3object.go
@@ -61,7 +61,7 @@ func UpdateIndexdRecord(uuid, rev string, indexdInfo *IndexdInfo, body []byte) (
 	client.RetryMax = MaxRetries
 	resp, err := client.Do(req)
 	if resp.StatusCode == 403 {
-		log.Printf("Possible auth issue for Indexd user %s", indexdInfo.Username)
+		log.Printf("Possible auth issue for Indexd user '%s' (basic auth)", indexdInfo.Username)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

This adds a specific log message if there is a 403 error from the `UpdateIndexdRecord` function. 
The 403 error is likely the result of a non-existent user in the Basic Auth for the indexd request. 

See this slack thread for context: https://cdis.slack.com/archives/C0294A7KVE0/p1749828034955709

JIRA ticket: [PPS-2067](https://ctds-planx.atlassian.net/browse/PPS-2067)

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

* Add a log message for a 403 error from `UpdateIndexdRecord`

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PPS-2067]: https://ctds-planx.atlassian.net/browse/PPS-2067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ